### PR TITLE
Adiciona autorização baseada em roles para proteção de endpoints

### DIFF
--- a/StockApp.API/Controllers/CategoriesController.cs
+++ b/StockApp.API/Controllers/CategoriesController.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using StockApp.Application.DTOs;
 using StockApp.Application.Interfaces;
 
 namespace StockApp.API.Controllers
 {
+    [Authorize(Roles = "Admin")]
     [Route("/api/[controller]")]
     [ApiController]
     public class CategoriesController : ControllerBase

--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -3,9 +3,11 @@ using StockApp.Application.DTOs;
 using StockApp.Application.Interfaces;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 
 namespace StockApp.API.Controllers;
 
+[Authorize(Roles = "Admin")]
 [ApiController]
 [Route("api/[controller]")]
 

--- a/StockApp.API/Controllers/SuppliersController.cs
+++ b/StockApp.API/Controllers/SuppliersController.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using StockApp.Application.DTOs;
 using StockApp.Application.Interfaces;
 
 namespace StockApp.API.Controllers
 {
+    [Authorize(Roles = "Admin")]
     [Route("/api/[controller]")]
     [ApiController]
     public class SuppliersController : ControllerBase

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.25" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Esta PR implementa a autorização baseada em roles utilizando JWT para proteger endpoints da API.
As principais mudanças incluem:
- Configuração do middleware de autenticação e autorização no Program.cs
- Aplicação do atributo [Authorize(Roles = "Admin")] nos controllers Products, Suppliers e Categories.