### PR TITLE
Implementação do sistema de permissões granulares

### DIFF
--- a/StockApp.API/Controllers/InventoryController.cs
+++ b/StockApp.API/Controllers/InventoryController.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using StockApp.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 
 namespace StockApp.API.Controllers
 {
+    [Authorize(Policy = "CanManageStock")]
     [Route("/api/[controller]")]
     [ApiController]
     public class InventoryController : ControllerBase
@@ -12,7 +14,7 @@ namespace StockApp.API.Controllers
         {
             _inventoryService = inventoryService;
         }
-
+        [Authorize(Policy = "CanManageStock")]
         [HttpPost("replenish-stock")]
         public async Task<IActionResult> ReplenishStock()
         {

--- a/StockApp.API/Infrastructure/Authorization/PermissionHandler.cs
+++ b/StockApp.API/Infrastructure/Authorization/PermissionHandler.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+namespace StockApp.API.Infrastructure.Authorization
+{
+    public class PermissionHandler : AuthorizationHandler<PermissionRequirement>
+
+    {
+        protected override Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            PermissionRequirement requirement)
+        {
+            if (context.User.HasClaim(c => c.Type == "Permission" && c.Value == requirement.Permission))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/StockApp.API/Infrastructure/Authorization/PermissionRequirement.cs
+++ b/StockApp.API/Infrastructure/Authorization/PermissionRequirement.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace StockApp.API.Infrastructure.Authorization
+{
+    public class PermissionRequirement : IAuthorizationRequirement
+    {
+        public string Permission { get; }
+
+        public PermissionRequirement(string permission)
+        {
+            Permission = permission;
+        }
+    }
+}

--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -15,6 +15,8 @@ using StockApp.Infra.Data.Repositories;
 using Serilog;
 using Serilog.Events;
 using StockApp.Application.Services;
+using StockApp.API.Infrastructure.Authorization;
+using Microsoft.AspNetCore.Authorization;
 
 internal class Program
 {
@@ -151,7 +153,12 @@ internal class Program
             builder.Services.AddAuthorization(options =>
             {
                 options.AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));
+
+                options.AddPolicy("CanManageStock", policy =>
+                     policy.Requirements.Add(new PermissionRequirement("CanManageStock")));
             });
+
+            builder.Services.AddSingleton<IAuthorizationHandler, PermissionHandler>();
 
             var app = builder.Build();
 

--- a/StockApp.Infra.Data/Identity/AuthService.cs
+++ b/StockApp.Infra.Data/Identity/AuthService.cs
@@ -37,7 +37,8 @@ namespace StockApp.Infra.Data.Identity
                 Subject = new ClaimsIdentity(new[]
                 {
                     new Claim(ClaimTypes.Name, user.Username),
-                    new Claim(ClaimTypes.Role, user.Role)
+                    new Claim(ClaimTypes.Role, user.Role),
+                    new Claim("Permission", "CanManageStock")
                 }),
                 Expires = DateTime.UtcNow.AddMinutes(double.Parse(_configuration["Jwt:ExpireMinutes"])),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)


### PR DESCRIPTION
Implementação do sistema de permissões granulares com uso de policy personalizada (CanManageStock), conforme solicitado na atividade:

- Criada a classe PermissionRequirement implementando IAuthorizationRequirement;
- Criado o handler PermissionHandler para validar claims de permissão;
- Registrada a policy CanManageStock no Program.cs;
- Aplicada a policy no InventoryController;
- Token JWT atualizado para incluir a claim "Permission": "CanManageStock" (via AuthService);